### PR TITLE
fix services.exim.environment.DISABLE_IPV6 error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - ./exim_log:/var/log/exim4
 
     environment:
-      DISABLE_IPV6: true
+      DISABLE_IPV6: "true"
       TZ: ${TOTUMTIMEZONE}
     
     restart: always


### PR DESCRIPTION
[fix] WARNING: The SSLON variable is not set. Defaulting to a blank string.
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.exim.environment.DISABLE_IPV6 contains true, which is an invalid type, it should be a string, number, or a null